### PR TITLE
Feat/leaderboard

### DIFF
--- a/src/main/java/com/project/reversi/config/SecurityConfig.java
+++ b/src/main/java/com/project/reversi/config/SecurityConfig.java
@@ -4,7 +4,6 @@ import com.project.reversi.model.User;
 import com.project.reversi.repository.UserRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -59,6 +58,7 @@ public class SecurityConfig {
             .antMatchers("/api/auth/**").permitAll()
             .antMatchers("/h2-console/**").permitAll()
             .antMatchers("/api/v1/sessions/**").permitAll()
+            .antMatchers("/api/v1/leaderboard/**").permitAll()
             .anyRequest().authenticated())
         .formLogin(form -> form
       .successHandler((request, response, authentication) -> {

--- a/src/main/java/com/project/reversi/controllers/LeaderboardController.java
+++ b/src/main/java/com/project/reversi/controllers/LeaderboardController.java
@@ -1,0 +1,48 @@
+package com.project.reversi.controllers;
+
+
+import com.project.reversi.dto.LeaderboardRow;
+import com.project.reversi.model.User;
+import com.project.reversi.repository.LeaderboardRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/leaderboard")
+public class LeaderboardController {
+
+
+  final LeaderboardRepository leaderboardRepository;
+
+  public LeaderboardController(LeaderboardRepository leaderboardRepository) {this.leaderboardRepository = leaderboardRepository;}
+
+  @GetMapping()
+  public ResponseEntity<Page<LeaderboardRow>> getLeaderBoard(
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "20") int size
+  ) {
+    Page<LeaderboardRow> leaderboard = leaderboardRepository.findLeaderboard(PageRequest.of(page, size));
+    return ResponseEntity.ok(leaderboard);
+  }
+
+  @GetMapping("/me")
+  @PreAuthorize("isAuthenticated()")
+  public ResponseEntity<LeaderboardRow> getMyStats(@AuthenticationPrincipal User currentUser) {
+    if (currentUser == null || currentUser.getId() == null) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+    LeaderboardRow stats = leaderboardRepository.findStatsByUserId(currentUser.getId());
+    if (stats == null) {
+      return ResponseEntity.noContent().build();
+    }
+    return ResponseEntity.ok(stats);
+  }
+}

--- a/src/main/java/com/project/reversi/dto/LeaderboardRow.java
+++ b/src/main/java/com/project/reversi/dto/LeaderboardRow.java
@@ -1,0 +1,20 @@
+package com.project.reversi.dto;
+
+public interface LeaderboardRow {
+
+  Long getUserId();
+
+  String getUsername();
+
+  Long getGames();
+
+  Long getWins();
+
+  Long getLosses();
+
+  Long getDraws();
+
+  Double getWinRate();
+
+  Long getRank();
+}

--- a/src/main/java/com/project/reversi/repository/LeaderboardRepository.java
+++ b/src/main/java/com/project/reversi/repository/LeaderboardRepository.java
@@ -1,0 +1,89 @@
+package com.project.reversi.repository;
+
+import com.project.reversi.dto.LeaderboardRow;
+import com.project.reversi.model.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+public interface LeaderboardRepository extends Repository<User, Long> {
+
+  String LEADERBOARD_BASE = """
+      SELECT *
+      FROM (
+               SELECT
+                   leaderboard.*,
+                   RANK() OVER (
+                       ORDER BY wins DESC,
+                                winRate DESC,
+                                losses ASC
+                   ) AS rank
+               FROM (
+                        SELECT
+                            u.id AS userId,
+                            u.username AS username,
+
+                            COUNT(*) AS games,
+
+                            SUM(CASE
+                                    WHEN (p.color = 'BLACK' AND gs.game_state = 'BLACK_WINS')
+                                        OR (p.color = 'WHITE' AND gs.game_state = 'WHITE_WINS')
+                                        THEN 1 ELSE 0 END) AS wins,
+
+                            SUM(CASE
+                                    WHEN (p.color = 'BLACK' AND gs.game_state = 'WHITE_WINS')
+                                        OR (p.color = 'WHITE' AND gs.game_state = 'BLACK_WINS')
+                                        THEN 1 ELSE 0 END) AS losses,
+
+                            SUM(CASE WHEN gs.game_state = 'TIE' THEN 1 ELSE 0 END) AS draws,
+
+                            SUM(CASE
+                                    WHEN (p.color = 'BLACK' AND gs.game_state = 'BLACK_WINS')
+                                        OR (p.color = 'WHITE' AND gs.game_state = 'WHITE_WINS')
+                                        THEN 1 ELSE 0 END) * 1.0 / NULLIF(COUNT(*), 0) AS winRate
+                        FROM app_user u
+                                 JOIN player p ON u.id = p.user_id
+                                 JOIN game_session gs ON p.session_id = gs.session_id
+                        WHERE gs.game_type = 'PLAYER_VS_PLAYER'
+                          AND gs.game_state <> 'IN_PROGRESS'
+                        GROUP BY u.id, u.username
+                    ) leaderboard
+           ) ranked
+      """;
+
+  String LEADERBOARD_ORDER = """
+      ORDER BY
+          wins DESC,
+          winRate DESC,
+          losses ASC
+      """;
+
+  String LEADERBOARD_COUNT = """
+      SELECT COUNT(*)
+      FROM (
+               SELECT u.id
+               FROM app_user u
+                        JOIN player p ON u.id = p.user_id
+                        JOIN game_session gs ON p.session_id = gs.session_id
+               WHERE gs.game_type = 'PLAYER_VS_PLAYER'
+                 AND gs.game_state <> 'IN_PROGRESS'
+               GROUP BY u.id
+           ) leaderboard
+      """;
+
+  @Query(
+      value = LEADERBOARD_BASE + LEADERBOARD_ORDER,
+      countQuery = LEADERBOARD_COUNT,
+      nativeQuery = true
+  )
+  Page<LeaderboardRow> findLeaderboard(Pageable pageable);
+
+  @Query(
+      value = LEADERBOARD_BASE + " WHERE userId = :userId",
+      nativeQuery = true
+  )
+  LeaderboardRow findStatsByUserId(@Param("userId") Long userId);
+
+}

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -14,6 +14,7 @@
     <button id="newGameBtn">New Game</button>
     <button id="joinGameBtn">Join Game</button>
     <button id="findMatchBtn">Find Match</button>
+    <button id="leaderBoardBtn">Leaderboard</button>
 </div>
 
 <!-- GAME PAGE (hidden until a session is active) -->
@@ -51,6 +52,33 @@
     </div>
 </div>
 
+<div id="leaderboardPage" class="hidden">
+    <div class="leaderboard-card">
+        <button id="leaderboardMenuBtn">Menu</button>
+        <div id="myStats" class="hidden">
+            <p><strong>Your Rank:</strong> <span id="myRank"></span></p>
+            <p><strong>Wins:</strong> <span id="myWins"></span></p>
+            <p><strong>Losses:</strong> <span id="myLosses"></span></p>
+            <p><strong>Win Rate:</strong> <span id="myWinRate"></span></p>
+        </div>
+
+        <h2>Global Leaderboard</h2>
+        <table id="leaderboardTable">
+            <thead>
+            <tr>
+                <th>Rank</th>
+                <th>Player</th>
+                <th>Wins</th>
+                <th>Losses</th>
+                <th>Win Rate</th>
+            </tr>
+            </thead>
+            <tbody id="leaderboardBody"></tbody>
+        </table>
+
+    </div>
+</div>
+
 <!-- Overlay for new game / join forms -->
 <div id="overlay" class="hidden">
     <div id="overlayContent">
@@ -66,6 +94,7 @@
 <script src="js/matchmaking.js"></script>
 <script src="js/menu.js"></script>
 <script src="js/game.js"></script>
+<script src ="js/leaderboard.js"></script>
 <script src="js/app.js"></script>
 
 </body>

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -9,6 +9,7 @@ document.addEventListener("DOMContentLoaded", function() {
   Reversi.elements.newGameBtn = document.getElementById("newGameBtn");
   Reversi.elements.joinGameBtn = document.getElementById("joinGameBtn");
   Reversi.elements.findMatchBtn = document.getElementById("findMatchBtn");
+  Reversi.elements.leaderBoardBtn = document.getElementById("leaderBoardBtn")
   Reversi.elements.overlay = document.getElementById("overlay");
   Reversi.elements.overlayTitle = document.getElementById("overlayTitle");
   Reversi.elements.overlayBody = document.getElementById("overlayBody");
@@ -24,7 +25,16 @@ document.addEventListener("DOMContentLoaded", function() {
   Reversi.elements.sessionIdLabel = document.getElementById("sessionIdLabel");
   Reversi.elements.copySessionIdBtn = document.getElementById("copySessionIdBtn");
   Reversi.elements.boardDiv = document.getElementById("board");
+  Reversi.elements.leaderboardPage = document.getElementById("leaderboardPage")
   Reversi.elements.gameContainer = document.getElementById("gameContainer");
+  Reversi.elements.leaderboardMenuBtn = document.getElementById("leaderboardMenuBtn");
+  Reversi.elements.leaderboardTableBody = document.getElementById("leaderboardBody");
+  Reversi.elements.myStats = document.getElementById("myStats");
+  Reversi.elements.myRank = document.getElementById("myRank");
+  Reversi.elements.myWins = document.getElementById("myWins");
+  Reversi.elements.myLosses = document.getElementById("myLosses");
+  Reversi.elements.myWinRate = document.getElementById("myWinRate");
+  Reversi.elements.leaderboardTableBody = document.getElementById("leaderboardBody");
 
   Reversi.config.WEBSOCKET_ENDPOINT = "/ws/game";
 
@@ -42,6 +52,8 @@ document.addEventListener("DOMContentLoaded", function() {
   Reversi.elements.newGameBtn.addEventListener("click", window.Menu.showNewGameOptions);
   Reversi.elements.joinGameBtn.addEventListener("click", window.Menu.showJoinGameForm);
   Reversi.elements.findMatchBtn.addEventListener("click", () => window.Matchmaking.showMatchmakingForm());
+  Reversi.elements.leaderBoardBtn.addEventListener("click",() => window.Leaderboard.showLeaderBoard())
+  Reversi.elements.leaderboardMenuBtn.addEventListener("click", () => window.Leaderboard.showMenu())
   Reversi.elements.copySessionIdBtn.addEventListener("click", window.Game.copySessionId);
   Reversi.elements.overlayCloseButton.addEventListener("click",() => Reversi.elements.overlay.classList.add("hidden"))
 

--- a/src/main/resources/static/js/leaderboard.js
+++ b/src/main/resources/static/js/leaderboard.js
@@ -1,0 +1,183 @@
+(() => {
+    const Reversi = (window.Reversi = window.Reversi || {});
+
+    let page = 0;
+    const size = 20;
+    let loading = false;
+    let last = false;
+    let scrollBound = false;
+
+    function showLeaderBoard() {
+        const {menuPage, leaderboardPage} = Reversi.elements;
+        menuPage.classList.add("hidden");
+
+        // Show leaderboard view
+        leaderboardPage.classList.remove("hidden");
+        resetLeaderboard();
+        // load user stats if authenticated
+        loadMyStats();
+        // Fill enough rows to allow scrolling
+        fillToViewport();
+        // Bind scroll only once
+        if (!scrollBound) {
+            scrollBound = true;
+            window.addEventListener("scroll", onScroll);
+        }
+    }
+
+    function showMenu() {
+        const {menuPage, leaderboardPage} = Reversi.elements;
+        leaderboardPage.classList.add("hidden");
+        menuPage.classList.remove("hidden");
+        if (scrollBound) {
+            window.removeEventListener("scroll", onScroll);
+            scrollBound = false;
+        }
+        window.scrollTo(0, 0);
+    }
+
+    function onScroll() {
+        const doc = document.documentElement;
+        const nearBottom =
+            window.innerHeight + window.scrollY >= doc.scrollHeight - 200;
+        if (nearBottom) loadMore();
+    }
+
+    function resetLeaderboard() {
+        page = 0;
+        loading = false;
+        last = false;
+
+        const {leaderboardTableBody} = Reversi.elements;
+        if (leaderboardTableBody) leaderboardTableBody.innerHTML = ""; // clear old rows
+    }
+
+    function needsMoreRows() {
+        const doc = document.documentElement;
+        return doc.scrollHeight <= window.innerHeight + 1;
+    }
+
+    async function fillToViewport() {
+        while (!last && needsMoreRows()) {
+            const loaded = await loadMore();
+            if (!loaded) break;
+        }
+    }
+
+    async function loadMore() {
+        if (loading || last) return false;
+        loading = true;
+
+        try {
+            const res = await fetch(`/api/v1/leaderboard?page=${page}&size=${size}`);
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            const data = await res.json();
+            if (!data) {
+                last = true;
+                return false;
+            }
+
+            appendRows(data.content || []);
+
+            last = data.last === true || (data.content || []).length === 0;
+            page += 1;
+            return true;
+        } catch (e) {
+            console.error("Failed to load leaderboard:", e);
+            last = true; // stop retry spam if endpoint fails
+            return false;
+        } finally {
+            loading = false;
+        }
+    }
+
+    function appendRows(rows) {
+        const {leaderboardTableBody} = Reversi.elements;
+        if (!leaderboardTableBody) {
+            console.error("leaderboardTable tbody not found. Did you add it to HTML?");
+            return;
+        }
+        for (const r of rows) {
+            const tr = document.createElement("tr");
+            const rankCell = document.createElement("td");
+            rankCell.textContent = r.rank ?? "";
+            const nameCell = document.createElement("td");
+            nameCell.textContent = r.username ?? "";
+            const winsCell = document.createElement("td");
+            winsCell.textContent = r.wins ?? 0;
+            const lossesCell = document.createElement("td");
+            lossesCell.textContent = r.losses ?? 0;
+            const winRateCell = document.createElement("td");
+            winRateCell.textContent = r.winRate != null ? (r.winRate * 100).toFixed(1) + "%" : "";
+            tr.append(rankCell, nameCell, winsCell, lossesCell, winRateCell);
+            leaderboardTableBody.appendChild(tr);
+        }
+    }
+
+
+    async function loadMyStats() {
+        let res;
+        try {
+            res = await fetch("/api/v1/leaderboard/me", {credentials: "include"});
+        } catch (e) {
+            hideMyStats();
+            return;
+        }
+
+        if (res.redirected && res.url.includes("/login")) {
+            // not logged in
+            hideMyStats();
+            return;
+        }
+
+        // Logged in but no games yet
+        if (res.status === 204) {
+            showEmptyMyStats();
+            return;
+        }
+        if (!res.ok) {
+            hideMyStats();
+            return;
+        }
+
+        const me = await res.json();
+
+        const {myRank, myWins, myLosses, myWinRate, myStats} = Reversi.elements;
+        if (!myStats || !myRank || !myWins || !myLosses || !myWinRate) {
+            return;
+        }
+        setMyStatsMessage("");
+        myRank.textContent = "#" + me.rank;
+        myWins.textContent = me.wins;
+        myLosses.textContent = me.losses;
+        myWinRate.textContent = (me.winRate * 100).toFixed(1) + "%";
+        myStats.classList.remove("hidden");
+    }
+
+    function hideMyStats() {
+        const {myStats} = Reversi.elements;
+        if (myStats) myStats.classList.add("hidden");
+    }
+
+    function showEmptyMyStats() {
+        const {myStats} = Reversi.elements;
+        if (!myStats) return;
+        setMyStatsMessage("Play your first game to appear on the leaderboard!");
+        myStats.classList.remove("hidden");
+    }
+
+    function setMyStatsMessage(message) {
+        const {myStats} = Reversi.elements;
+        if (!myStats) return;
+        let messageNode = myStats.querySelector(".my-stats-message");
+        if (!messageNode) {
+            messageNode = document.createElement("p");
+            messageNode.className = "my-stats-message";
+            myStats.appendChild(messageNode);
+        }
+        messageNode.textContent = message;
+        messageNode.classList.toggle("hidden", message.trim() === "");
+    }
+
+    window.Leaderboard = {showLeaderBoard, showMenu};
+})();

--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -34,6 +34,50 @@ button {
 /* MENU PAGE (initially visible) */
 #menuPage {
   margin-top: 50px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+#menuPage button {
+  min-width: 200px;
+}
+
+/* Leaderboard page */
+#leaderboardPage {
+  margin-top: 40px;
+  display: flex;
+  justify-content: center;
+}
+
+.leaderboard-card {
+  width: min(900px, 95%);
+  background-color: #ffffff;
+  border: 1px solid #d9d9d9;
+  border-radius: 8px;
+  padding: 16px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+}
+
+#leaderboardTable {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0 auto;
+}
+
+#leaderboardTable th,
+#leaderboardTable td {
+  padding: 10px 12px;
+  border-bottom: 1px solid #e2e2e2;
+}
+
+#leaderboardTable th {
+  background-color: #f5f5f5;
+}
+
+#leaderboardTable td:nth-child(2) {
+  text-align: left;
 }
 
 /* GAME PAGE */

--- a/src/test/java/com/project/reversi/repository/LeaderboardRepositoryTest.java
+++ b/src/test/java/com/project/reversi/repository/LeaderboardRepositoryTest.java
@@ -1,0 +1,86 @@
+package com.project.reversi.repository;
+
+import com.project.reversi.dto.LeaderboardRow;
+import com.project.reversi.model.Board;
+import com.project.reversi.model.GameSession;
+import com.project.reversi.model.GameState;
+import com.project.reversi.model.GameType;
+import com.project.reversi.model.Player;
+import com.project.reversi.model.PlayerColor;
+import com.project.reversi.model.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DataJpaTest
+class LeaderboardRepositoryTest {
+
+  @Autowired
+  private LeaderboardRepository leaderboardRepository;
+
+  @Autowired
+  private JpaGameSessionRepository sessionRepository;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Test
+  void aggregatesLeaderboardRowsFromFinishedSessions() {
+    User alice = userRepository.save(new User("alice", "pw"));
+    User bob = userRepository.save(new User("bob", "pw"));
+    User carol = userRepository.save(new User("carol", "pw"));
+
+    createFinishedSession(alice, bob, GameState.WHITE_WINS); // Alice wins as WHITE
+    createFinishedSession(bob, alice, GameState.WHITE_WINS); // Bob wins as WHITE
+    createFinishedSession(alice, carol, GameState.TIE);
+    createFinishedSession(bob, carol, GameState.BLACK_WINS); // Carol wins as BLACK
+    createInProgressSession(alice, bob); // should not count
+
+    Page<LeaderboardRow> page = leaderboardRepository.findLeaderboard(PageRequest.of(0, 10));
+    List<LeaderboardRow> rows = page.getContent();
+
+    assertEquals(3, rows.size());
+    assertRow(rows.get(0), carol, 2, 1, 0, 1);
+    assertRow(rows.get(1), alice, 3, 1, 1, 1);
+    assertRow(rows.get(2), bob, 3, 1, 2, 0);
+  }
+
+  private void assertRow(LeaderboardRow row, User user, long games, long wins, long losses, long draws) {
+    assertEquals(user.getId(), row.getUserId());
+    assertEquals(user.getUsername(), row.getUsername());
+    assertEquals(games, row.getGames());
+    assertEquals(wins, row.getWins());
+    assertEquals(losses, row.getLosses());
+    assertEquals(draws, row.getDraws());
+  }
+
+  private GameSession createFinishedSession(User whiteUser, User blackUser, GameState gameState) {
+    Player white = new Player(PlayerColor.WHITE);
+    white.setAccount(whiteUser);
+    Player black = new Player(PlayerColor.BLACK);
+    black.setAccount(blackUser);
+
+    GameSession session = new GameSession(new Board(8, 8), white, GameType.PLAYER_VS_PLAYER);
+    session.joinSession(black);
+    session.setGameState(gameState);
+    return sessionRepository.save(session);
+  }
+
+  private GameSession createInProgressSession(User whiteUser, User blackUser) {
+    Player white = new Player(PlayerColor.WHITE);
+    white.setAccount(whiteUser);
+    Player black = new Player(PlayerColor.BLACK);
+    black.setAccount(blackUser);
+
+    GameSession session = new GameSession(new Board(8, 8), white, GameType.PLAYER_VS_PLAYER);
+    session.joinSession(black);
+    return sessionRepository.save(session);
+  }
+}


### PR DESCRIPTION
**Goal**

 Provide a competitive global leaderboard that ranks users based on their performance in finished Reversi games.

**Ranking Rules**


1. Sort by number of wins (descending)
2. Tie-breaker: win rate (wins / total games)
3. Tie-breaker: number of losses (ascending)
4. Only finished PvP games are counted


**Acceptance Criteria**

- Backend API provides leaderboard rows per user
- Frontend displays a ranked list of players
- Ranking rules are respected
- User can view their rank and stats









