### PR TITLE
Add live spectator mode with shareable game links

### DIFF
--- a/docs/spectator-mode-manual-scenarios.md
+++ b/docs/spectator-mode-manual-scenarios.md
@@ -1,0 +1,10 @@
+# Spectator mode focused manual scenarios
+
+1. Create a PVP game in one authenticated browser and join it with a second account. In a signed-out window, choose **Watch Game**, enter the session ID, and confirm that no player seat changes.
+2. Open `/?spectate=<sessionId>` in a signed-out window. Confirm the board, both names, scores, and active turn render without a login redirect.
+3. Make moves from both player windows. Confirm the spectator updates through `/topic/game-progress/<sessionId>` without refreshing and never shows blue legal-move indicators.
+4. Click every type of spectator board cell and inspect the Network panel. Confirm no move request is sent.
+5. Reach a position in which one color passes. Confirm the spectator status names the passed color and the player who moves next.
+6. Complete a game, then open its spectator link in a new window. Confirm the final board, scores, names, and result render immediately.
+7. Enter an invalid session ID and open an invalid direct link. Confirm a clear “Game not found or no longer available” error appears and no game view opens.
+8. Send `POST /api/v1/sessions/<sessionId>/moves` manually as a signed-out user and as an authenticated non-player. Confirm responses are respectively 401 and 403 and the board is unchanged.

--- a/docs/spectator-mode-spec.md
+++ b/docs/spectator-mode-spec.md
@@ -1,0 +1,95 @@
+# Spec: Live spectator mode
+
+## Objective
+
+Allow anyone with a session ID to watch an active or completed Othello game without joining it. A spectator sees the board, scores, player names, active turn, pass information, and final result in real time, but never receives move hints or an interactive board. Authenticated PVP moves must also be rejected unless the caller owns the submitted color.
+
+## Tech Stack
+
+- Java 17, Spring Boot 2.7.5, Spring MVC/Security, Spring Data JPA
+- Server-rendered static HTML/CSS and browser JavaScript
+- SockJS/STOMP using the existing `/topic/game-progress/{sessionId}` topic
+- JUnit 5, Mockito, MockMvc, H2
+
+## Commands
+
+- Extract skills: `mvn -q skillsjars:extract -Ddir=.agents/skills`
+- Compile: `mvn -q -DskipTests test-compile`
+- Test: `mvn test`
+- Package: `mvn clean install`
+- Focused browser-logic tests: `node --test src/test/js/spectator-mode.test.js`
+
+## Project Structure
+
+- `src/main/java/com/project/reversi` — session model, REST controller, and game services
+- `src/main/resources/static` — menu, game rendering, spectator flow, and styles
+- `src/test/java/com/project/reversi` — controller and service tests
+- `src/test/js` — dependency-free tests for spectator URL and read-only-state logic
+- `docs` — feature specification and focused manual scenarios
+
+## Code Style
+
+Follow the existing Java formatting and browser-module pattern:
+
+```java
+boolean ownsColor = session.getPlayers().stream()
+                           .filter(player -> player.getColor() == playerColor)
+                           .map(Player::getAccount)
+                           .anyMatch(account -> sameUser(account, currentUser));
+if (!ownsColor) {
+  throw new AccessDeniedException("Player does not own the requested color");
+}
+```
+
+Browser code remains in an IIFE and exposes only the functions needed by the other existing modules. Names describe behavior (`watchGame`, `isSpectator`, `spectateSessionIdFromSearch`).
+
+## Testing Strategy
+
+- Controller tests prove that session reads remain public and invalid IDs return 404.
+- Service/controller tests prove anonymous and non-owner PVP moves are rejected while the owning player can move.
+- Existing service tests protect PVP/PVC game behavior.
+- Dependency-free Node tests cover direct spectator links and read-only rendering decisions.
+- Focused manual scenarios verify the real SockJS/STOMP update path, errors, pass messaging, and completed-game rendering.
+
+## Boundaries
+
+- Always: keep spectator identity separate from player state; reuse the existing session GET and WebSocket topic; run all tests before commit.
+- Ask first: add third-party dependencies, change CI, or introduce private-game access rules.
+- Never: join a spectator to a game, expose move hints to spectators, allow spectator board actions, or weaken existing authentication.
+
+## Implementation Plan
+
+1. Add authorization-focused tests, then enforce PVP color ownership in the game service/controller.
+2. Add spectator-state tests, then implement Watch Game and `?spectate=` entry flows.
+3. Make rendering read-only for spectators and surface turn, pass, and final-result status.
+4. Verify live updates continue through the existing topic and document focused browser scenarios.
+5. Run the complete Maven lifecycle, review the diff, and publish a draft PR.
+
+## Tasks
+
+- [x] Protect PVP move ownership.
+  - Acceptance: anonymous callers receive 401; authenticated non-owners receive 403; the active color owner retains existing move behavior.
+  - Verify: focused controller and service tests.
+  - Files: `GameService.java`, `SessionController.java`, their tests.
+- [x] Implement spectator entry and read-only rendering.
+  - Acceptance: menu and direct-link flows fetch but never join; no hints or click-driven moves are possible.
+  - Verify: dependency-free Node tests and manual browser flow.
+  - Files: `index.html`, `app.js`, `menu.js`, `game.js`, `spectator-mode.js`, JS tests.
+- [x] Surface spectator game progress.
+  - Acceptance: current turn, scores, names, pass information, final result, invalid-session errors, and WebSocket updates are visible.
+  - Verify: DTO/controller tests and focused manual scenarios.
+  - Files: `GameSession.java`, `GameSessionSummaryDTO.java`, UI resources, tests, manual scenarios.
+
+## Success Criteria
+
+- A session ID entered through Watch Game loads the game without taking a seat.
+- `?spectate=<sessionId>` opens the same read-only flow automatically.
+- Active and completed sessions render all state required by issue #14.
+- Spectators subscribe to existing progress messages but cannot fetch legal moves or submit moves through the UI.
+- PVP moves are accepted only from the account that owns the submitted active color.
+- Invalid/unavailable IDs show a clear error and leave the user outside game mode.
+- Existing PVP and PVC behavior and tests remain green.
+
+## Open Questions
+
+None. Issue #14 defines public spectator access; private games, chat, counts, and replay remain out of scope.

--- a/src/main/java/com/project/reversi/controllers/SessionController.java
+++ b/src/main/java/com/project/reversi/controllers/SessionController.java
@@ -15,6 +15,7 @@ import com.project.reversi.services.GameService;
 import com.project.reversi.services.GameSessionService;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -23,7 +24,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -166,7 +169,8 @@ public class SessionController {
   @PostMapping("/{sessionId}/moves")
   public ResponseEntity<MoveResponseDTO> makeMove(
       @PathVariable String sessionId,
-      @RequestBody MoveRequestDTO moveRequest
+      @RequestBody MoveRequestDTO moveRequest,
+      @AuthenticationPrincipal User currentUser
   ) {
     MoveResponseDTO response = new MoveResponseDTO();
     PlayerColor playerColor = moveRequest.getColor();
@@ -175,7 +179,8 @@ public class SessionController {
           sessionId,
           moveRequest.getRow(),
           moveRequest.getColumn(),
-          playerColor
+          playerColor,
+          currentUser
       );
 
       switch (result) {
@@ -200,6 +205,18 @@ public class SessionController {
           response
       );
       return ResponseEntity.ok(response);
+    }
+    catch (AuthenticationCredentialsNotFoundException e) {
+      response.setMessage("Authentication is required for PVP moves");
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
+    }
+    catch (AccessDeniedException e) {
+      response.setMessage("You do not own the requested player color");
+      return ResponseEntity.status(HttpStatus.FORBIDDEN).body(response);
+    }
+    catch (NoSuchElementException e) {
+      response.setMessage("Session not found");
+      return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
     }
     catch (IllegalArgumentException e) {
       logger.error("Error processing move: {}", e.getMessage());

--- a/src/main/java/com/project/reversi/dto/GameSessionSummaryDTO.java
+++ b/src/main/java/com/project/reversi/dto/GameSessionSummaryDTO.java
@@ -18,6 +18,7 @@ public class GameSessionSummaryDTO {
   private int whiteScore;
   private int blackScore;
   private String gameState;
+  private String lastPassedPlayerColor;
 
   // Getters and setters
 
@@ -89,6 +90,14 @@ public class GameSessionSummaryDTO {
     return gameState;
   }
 
+  public String getLastPassedPlayerColor() {
+    return lastPassedPlayerColor;
+  }
+
+  public void setLastPassedPlayerColor(String lastPassedPlayerColor) {
+    this.lastPassedPlayerColor = lastPassedPlayerColor;
+  }
+
   public void setBlackScore(int pieceCount) {
     blackScore = pieceCount;
   }
@@ -127,6 +136,9 @@ public class GameSessionSummaryDTO {
     summary.setCurrentPlayerNickname(resolveNickname(currentPlayer));
     summary.setGameType(session.getGameType().name());
     summary.setGameState(session.getGameState().name());
+    summary.setLastPassedPlayerColor(
+        session.getLastPassedPlayerColor() == null ? null : session.getLastPassedPlayerColor().name()
+    );
     summary.setWhiteScore(session.getWhiteScore());
     summary.setBlackScore(session.getBlackScore());
     return summary;

--- a/src/main/java/com/project/reversi/model/GameSession.java
+++ b/src/main/java/com/project/reversi/model/GameSession.java
@@ -51,6 +51,9 @@ public class GameSession {
   private int whiteScore;         // piece count for white
   private int blackScore;         // piece count for black
 
+  @Enumerated(EnumType.STRING)
+  private PlayerColor lastPassedPlayerColor;
+
 
   @OneToMany(mappedBy = "session", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Player> players;   // Two players; for PVP, second can join later; for PVC, computer is auto-added.
@@ -163,6 +166,10 @@ public class GameSession {
     return blackScore;
   }
 
+  public PlayerColor getLastPassedPlayerColor() {
+    return lastPassedPlayerColor;
+  }
+
   public void setBlackScore(int blackScore) {
     this.blackScore = blackScore;
   }
@@ -262,8 +269,10 @@ public class GameSession {
   }
 
   public void advanceTurnWithPass() {
+    lastPassedPlayerColor = null;
     advanceTurn(); // switch to next player
     if (getCurrentPlayer() != null && !hasValidMove(getCurrentPlayer().getColor())) {
+      lastPassedPlayerColor = getCurrentPlayer().getColor();
       advanceTurn(); // pass
     }
   }

--- a/src/main/java/com/project/reversi/services/GameService.java
+++ b/src/main/java/com/project/reversi/services/GameService.java
@@ -1,13 +1,18 @@
 package com.project.reversi.services;
 
 import com.project.reversi.model.GameSession;
+import com.project.reversi.model.GameType;
 import com.project.reversi.model.MoveResult;
 import com.project.reversi.model.Player;
 import com.project.reversi.model.PlayerColor;
+import com.project.reversi.model.User;
 import com.project.reversi.repository.JpaGameSessionRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.NoSuchElementException;
 
@@ -32,12 +37,58 @@ public class GameService {
    * @param row         The row for the move.
    * @param column      The column for the move.
    * @param playerColor The color of the player making the move.
-   * @return The resut of the move
+   * @return The result of the move
    */
-  public MoveResult makeMove(String sessionId, int row, int column, PlayerColor playerColor) {
+  MoveResult makeMove(String sessionId, int row, int column, PlayerColor playerColor) {
     GameSession session = sessionRepository.findById(sessionId)
                                            .orElseThrow(() -> new NoSuchElementException("Session not found: "
                                                                                          + sessionId));
+    return makeMove(session, row, column, playerColor);
+  }
+
+  @Transactional
+  public MoveResult makeMove(
+      String sessionId,
+      int row,
+      int column,
+      PlayerColor playerColor,
+      User currentUser
+  ) {
+    GameSession session = sessionRepository.findById(sessionId)
+                                           .orElseThrow(() -> new NoSuchElementException("Session not found: "
+                                                                                         + sessionId));
+    authorizePvpMove(session, playerColor, currentUser);
+    return makeMove(session, row, column, playerColor);
+  }
+
+  private void authorizePvpMove(GameSession session, PlayerColor playerColor, User currentUser) {
+    if (session.getGameType() != GameType.PLAYER_VS_PLAYER) {
+      return;
+    }
+    if (currentUser == null) {
+      throw new AuthenticationCredentialsNotFoundException("Authentication is required for PVP moves");
+    }
+    boolean ownsColor = session.getPlayers().stream()
+                               .filter(player -> player.getColor() == playerColor)
+                               .map(Player::getAccount)
+                               .anyMatch(account -> sameUser(account, currentUser));
+    if (!ownsColor) {
+      throw new AccessDeniedException("Player does not own the requested color");
+    }
+  }
+
+  private boolean sameUser(User account, User currentUser) {
+    if (account == null) {
+      return false;
+    }
+    if (account.getId() != null && currentUser.getId() != null) {
+      return account.getId().equals(currentUser.getId());
+    }
+    return account.getUsername().equals(currentUser.getUsername());
+  }
+
+  private MoveResult makeMove(GameSession session, int row, int column, PlayerColor playerColor) {
+    String sessionId = session.getSessionId();
     if (session.isFinished()) {
       logger.warn("Attempted move on finished session: {}", sessionId);
       return MoveResult.GAME_FINISHED;
@@ -71,6 +122,7 @@ public class GameService {
 
     if (session.isGameOver()) {
       session.finish();
+      sessionRepository.save(session);
       return MoveResult.GAME_FINISHED;
     }
 
@@ -81,6 +133,7 @@ public class GameService {
 
       if (session.isGameOver()) {
         session.finish();
+        sessionRepository.save(session);
         return MoveResult.GAME_FINISHED;
       }
     }

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -13,6 +13,7 @@
 <div id="menuPage">
     <button id="newGameBtn">New Game</button>
     <button id="joinGameBtn">Join Game</button>
+    <button id="watchGameBtn">Watch Game</button>
     <button id="findMatchBtn">Find Match</button>
     <button id="leaderBoardBtn">Leaderboard</button>
 </div>
@@ -26,10 +27,12 @@
         <div id="sessionDetails" class="hidden">
             <span id="sessionIdLabel">Session ID: -</span>
             <button id="copySessionIdBtn" type="button">Copy</button>
+            <button id="copyWatchLinkBtn" type="button">Copy watch link</button>
         </div>
     </div>
     <!-- Game container wrapping scoreboard and board -->
     <div id="gameContainer" class="hidden">
+        <p id="gameStatus" role="status" aria-live="polite"></p>
         <!-- Scoreboard -->
         <div id="scores">
             <div id="blackScoreBox" class="scoreBox">
@@ -93,6 +96,7 @@
 <script src="js/auth.js"></script>
 <script src="js/matchmaking.js"></script>
 <script src="js/menu.js"></script>
+<script src="js/spectator-mode.js"></script>
 <script src="js/game.js"></script>
 <script src ="js/leaderboard.js"></script>
 <script src="js/app.js"></script>

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -8,6 +8,7 @@ document.addEventListener("DOMContentLoaded", function() {
   Reversi.elements.gamePage = document.getElementById("gamePage");
   Reversi.elements.newGameBtn = document.getElementById("newGameBtn");
   Reversi.elements.joinGameBtn = document.getElementById("joinGameBtn");
+  Reversi.elements.watchGameBtn = document.getElementById("watchGameBtn");
   Reversi.elements.findMatchBtn = document.getElementById("findMatchBtn");
   Reversi.elements.leaderBoardBtn = document.getElementById("leaderBoardBtn")
   Reversi.elements.overlay = document.getElementById("overlay");
@@ -24,9 +25,11 @@ document.addEventListener("DOMContentLoaded", function() {
   Reversi.elements.sessionDetails = document.getElementById("sessionDetails");
   Reversi.elements.sessionIdLabel = document.getElementById("sessionIdLabel");
   Reversi.elements.copySessionIdBtn = document.getElementById("copySessionIdBtn");
+  Reversi.elements.copyWatchLinkBtn = document.getElementById("copyWatchLinkBtn");
   Reversi.elements.boardDiv = document.getElementById("board");
   Reversi.elements.leaderboardPage = document.getElementById("leaderboardPage")
   Reversi.elements.gameContainer = document.getElementById("gameContainer");
+  Reversi.elements.gameStatus = document.getElementById("gameStatus");
   Reversi.elements.leaderboardMenuBtn = document.getElementById("leaderboardMenuBtn");
   Reversi.elements.leaderboardTableBody = document.getElementById("leaderboardBody");
   Reversi.elements.myStats = document.getElementById("myStats");
@@ -39,9 +42,13 @@ document.addEventListener("DOMContentLoaded", function() {
   Reversi.config.WEBSOCKET_ENDPOINT = "/ws/game";
 
   Reversi.state.clientColor = Reversi.state.clientColor || "WHITE";
+  Reversi.state.isSpectator = Reversi.state.isSpectator || false;
   Reversi.state.currentSessionSummary = Reversi.state.currentSessionSummary || null;
   Reversi.state.stompClient = Reversi.state.stompClient || null;
+  Reversi.state.gameSubscription = Reversi.state.gameSubscription || null;
+  Reversi.state.gameSocket = Reversi.state.gameSocket || null;
   Reversi.state.renderSequence = Reversi.state.renderSequence || 0;
+  Reversi.state.lastAnnouncedGameState = Reversi.state.lastAnnouncedGameState || null;
   Reversi.state.matchmakingClient = Reversi.state.matchmakingClient || null;
   Reversi.state.matchmakingSubscription = Reversi.state.matchmakingSubscription || null;
   Reversi.state.matchmakingTicketId = Reversi.state.matchmakingTicketId || null;
@@ -51,11 +58,18 @@ document.addEventListener("DOMContentLoaded", function() {
 
   Reversi.elements.newGameBtn.addEventListener("click", window.Menu.showNewGameOptions);
   Reversi.elements.joinGameBtn.addEventListener("click", window.Menu.showJoinGameForm);
+  Reversi.elements.watchGameBtn.addEventListener("click", window.Menu.showWatchGameForm);
   Reversi.elements.findMatchBtn.addEventListener("click", () => window.Matchmaking.showMatchmakingForm());
   Reversi.elements.leaderBoardBtn.addEventListener("click",() => window.Leaderboard.showLeaderBoard())
   Reversi.elements.leaderboardMenuBtn.addEventListener("click", () => window.Leaderboard.showMenu())
   Reversi.elements.copySessionIdBtn.addEventListener("click", window.Game.copySessionId);
+  Reversi.elements.copyWatchLinkBtn.addEventListener("click", window.Game.copySpectatorLink);
   Reversi.elements.overlayCloseButton.addEventListener("click",() => Reversi.elements.overlay.classList.add("hidden"))
 
-  window.Auth.resumePendingActionIfAvailable();
+  const spectateSessionId = window.SpectatorMode.spectateSessionIdFromSearch(window.location.search);
+  if (spectateSessionId) {
+    window.Game.watchGame(spectateSessionId);
+  } else {
+    window.Auth.resumePendingActionIfAvailable();
+  }
 });

--- a/src/main/resources/static/js/game.js
+++ b/src/main/resources/static/js/game.js
@@ -17,7 +17,9 @@
       .then(res => res.json())
       .then(data => {
         console.log("New Game:", data);
+        Reversi.state.isSpectator = false;
         Reversi.state.clientColor = "WHITE";
+        Reversi.state.lastAnnouncedGameState = null;
         connectToSocket(data.sessionId);
         enterGame(data);
       })
@@ -51,7 +53,9 @@
       .then(res => res.json())
       .then(data => {
         console.log("Joined Game:", data);
+        Reversi.state.isSpectator = false;
         Reversi.state.clientColor = "BLACK";
+        Reversi.state.lastAnnouncedGameState = null;
         connectToSocket(data.sessionId);
         enterGame(data);
       })
@@ -61,6 +65,69 @@
         }
         console.error("Error joining game:", err);
       });
+  }
+
+  function watchGame(explicitSessionId) {
+    const sessionIdInput = document.getElementById("spectatorSessionIdInput");
+    const providedId = typeof explicitSessionId === "string" ? explicitSessionId.trim() : "";
+    const enteredId = sessionIdInput && typeof sessionIdInput.value === "string"
+      ? sessionIdInput.value.trim()
+      : "";
+    const targetSessionId = providedId || enteredId;
+    if (!targetSessionId) {
+      showSpectatorError("Please enter a session ID.");
+      return;
+    }
+
+    clearSpectatorError();
+    fetch(`/api/v1/sessions/${encodeURIComponent(targetSessionId)}`)
+      .then(response => {
+        if (!response.ok) {
+          if (response.status === 404) {
+            throw new Error("Game not found or no longer available.");
+          }
+          throw new Error("Unable to load this game. Please try again.");
+        }
+        return response.json();
+      })
+      .then(sessionSummary => {
+        Reversi.state.isSpectator = true;
+        Reversi.state.clientColor = null;
+        Reversi.state.lastAnnouncedGameState = null;
+        window.history.replaceState(
+          null,
+          "",
+          window.SpectatorMode.spectatorUrl(window.location.href, sessionSummary.sessionId)
+        );
+        Reversi.elements.overlay.classList.add("hidden");
+        connectToSocket(sessionSummary.sessionId);
+        enterGame(sessionSummary);
+      })
+      .catch(error => {
+        console.error("Error watching game:", error);
+        showSpectatorError(error.message);
+      });
+  }
+
+  function showSpectatorError(message) {
+    const { overlay, overlayTitle } = Reversi.elements;
+    overlay.classList.remove("hidden");
+    overlayTitle.textContent = "Watch a Game";
+    let errorElement = document.getElementById("spectatorError");
+    if (!errorElement) {
+      window.Menu.showWatchGameForm();
+      errorElement = document.getElementById("spectatorError");
+    }
+    errorElement.textContent = message;
+    errorElement.classList.remove("hidden");
+  }
+
+  function clearSpectatorError() {
+    const errorElement = document.getElementById("spectatorError");
+    if (errorElement) {
+      errorElement.textContent = "";
+      errorElement.classList.add("hidden");
+    }
   }
 
   function enterGame(sessionSummary) {
@@ -87,23 +154,33 @@
     gameContainer.classList.remove("hidden");
     Reversi.elements.blackScoreVal.textContent = sessionSummary.blackScore || 0;
     Reversi.elements.whiteScoreVal.textContent = sessionSummary.whiteScore || 0;
+    Reversi.elements.gameStatus.textContent = window.SpectatorMode.gameStatusText(
+      sessionSummary,
+      Reversi.state.isSpectator
+    );
 
     if (sessionSummary.gameState && sessionSummary.gameState !== "IN_PROGRESS") {
       renderBoard(sessionSummary.board.boardCells, []);
       updateScoreboardNames(sessionSummary);
       updateTurnHighlight(sessionSummary);
-      setTimeout(() => {
-        alert("Game Over! Result: " + sessionSummary.gameState);
-      }, 100);
+      if (!Reversi.state.isSpectator && Reversi.state.lastAnnouncedGameState !== sessionSummary.gameState) {
+        Reversi.state.lastAnnouncedGameState = sessionSummary.gameState;
+        setTimeout(() => {
+          alert("Game Over! Result: " + sessionSummary.gameState);
+        }, 100);
+      }
       return;
     }
 
     updateScoreboardNames(sessionSummary);
     updateTurnHighlight(sessionSummary);
 
-    const isMyTurn = sessionSummary.currentPlayerColor && Reversi.state.clientColor &&
-      sessionSummary.currentPlayerColor.toUpperCase() === Reversi.state.clientColor.toUpperCase();
-    if (!isMyTurn) {
+    const shouldRequestMoves = window.SpectatorMode.shouldRequestPossibleMoves({
+      isSpectator: Reversi.state.isSpectator,
+      clientColor: Reversi.state.clientColor,
+      currentPlayerColor: sessionSummary.currentPlayerColor
+    });
+    if (!shouldRequestMoves) {
       renderBoard(sessionSummary.board.boardCells, []);
       return;
     }
@@ -135,6 +212,13 @@
     boardDiv.style.gridTemplateRows = `repeat(${rows}, 50px)`;
 
     const validMovesLookup = {};
+    const canInteract = window.SpectatorMode.canInteractWithBoard({
+      isSpectator: Reversi.state.isSpectator,
+      clientColor: Reversi.state.clientColor,
+      currentPlayerColor: Reversi.state.currentSessionSummary
+        ? Reversi.state.currentSessionSummary.currentPlayerColor
+        : null
+    });
     if (Array.isArray(validMoves)) {
       validMoves.forEach(move => {
         validMovesLookup[`${move.row},${move.column}`] = true;
@@ -162,7 +246,10 @@
           cellDiv.appendChild(indicator);
         }
 
-        cellDiv.addEventListener("click", () => onCellClick(r, c));
+        if (canInteract) {
+          cellDiv.classList.add("interactive");
+          cellDiv.addEventListener("click", () => onCellClick(r, c));
+        }
         boardDiv.appendChild(cellDiv);
       }
     }
@@ -172,6 +259,13 @@
     console.log("Cell clicked:", row, col);
     if (!Reversi.state.currentSessionSummary || !Reversi.state.currentSessionSummary.sessionId) {
       console.error("No session available for making a move.");
+      return;
+    }
+    if (!window.SpectatorMode.canInteractWithBoard({
+      isSpectator: Reversi.state.isSpectator,
+      clientColor: Reversi.state.clientColor,
+      currentPlayerColor: Reversi.state.currentSessionSummary.currentPlayerColor
+    })) {
       return;
     }
     console.log("Current turn from session:", Reversi.state.currentSessionSummary.currentPlayerColor);
@@ -268,36 +362,66 @@
   }
 
   function connectToSocket(gameId) {
-    //console.log("connecting to the game");
+    disconnectFromSocket();
     let socket = new SockJS(Reversi.config.WEBSOCKET_ENDPOINT);
-    Reversi.state.stompClient = Stomp.over(socket);
-    Reversi.state.stompClient.connect({}, function (frame) {
+    const stompClient = Stomp.over(socket);
+    Reversi.state.gameSocket = socket;
+    Reversi.state.stompClient = stompClient;
+    stompClient.connect({}, function (frame) {
+      if (Reversi.state.stompClient !== stompClient) {
+        if (stompClient.connected) {
+          stompClient.disconnect();
+        }
+        return;
+      }
       console.log("connected to the frame: " + frame);
-      Reversi.state.stompClient.subscribe("/topic/game-progress/" + gameId, function (response) {
-        let data = JSON.parse(response.body);
-        //console.log(data);
-        Reversi.state.currentSessionSummary = data.sessionSummary;
-        renderGame(Reversi.state.currentSessionSummary);
-      });
+      Reversi.state.gameSubscription = stompClient.subscribe(
+        "/topic/game-progress/" + gameId,
+        function (response) {
+          let data = JSON.parse(response.body);
+          Reversi.state.currentSessionSummary = data.sessionSummary;
+          renderGame(Reversi.state.currentSessionSummary);
+        }
+      );
     });
   }
 
+  function disconnectFromSocket() {
+    if (Reversi.state.gameSubscription) {
+      Reversi.state.gameSubscription.unsubscribe();
+      Reversi.state.gameSubscription = null;
+    }
+    const clientWasConnected = Reversi.state.stompClient && Reversi.state.stompClient.connected;
+    if (clientWasConnected) {
+      Reversi.state.stompClient.disconnect();
+    }
+    if (!clientWasConnected && Reversi.state.gameSocket && Reversi.state.gameSocket.readyState !== 3) {
+      Reversi.state.gameSocket.close();
+    }
+    Reversi.state.stompClient = null;
+    Reversi.state.gameSocket = null;
+  }
+
   function showSessionInfo(summary) {
-    const { sessionDetails, sessionIdLabel, copySessionIdBtn } = Reversi.elements;
+    const { sessionDetails, sessionIdLabel, copySessionIdBtn, copyWatchLinkBtn } = Reversi.elements;
     if (summary && summary.sessionId) {
       sessionIdLabel.textContent = `Session ID: ${summary.sessionId}`;
       sessionDetails.classList.remove("hidden");
       copySessionIdBtn.textContent = "Copy";
       copySessionIdBtn.disabled = false;
+      copyWatchLinkBtn.textContent = "Copy watch link";
+      copyWatchLinkBtn.disabled = false;
     }
   }
 
   function hideSessionInfo() {
-    const { sessionDetails, sessionIdLabel, copySessionIdBtn } = Reversi.elements;
+    const { sessionDetails, sessionIdLabel, copySessionIdBtn, copyWatchLinkBtn } = Reversi.elements;
     sessionDetails.classList.add("hidden");
     sessionIdLabel.textContent = "Session ID: -";
     copySessionIdBtn.textContent = "Copy";
     copySessionIdBtn.disabled = false;
+    copyWatchLinkBtn.textContent = "Copy watch link";
+    copyWatchLinkBtn.disabled = false;
 
     if (Reversi.state.copyFeedbackTimeout) {
       clearTimeout(Reversi.state.copyFeedbackTimeout);
@@ -315,27 +439,48 @@
       : Promise.reject(new Error("Clipboard API unavailable"));
 
     promise
-      .then(() => provideCopyFeedback("Copied!"))
+      .then(() => provideCopyFeedback(Reversi.elements.copySessionIdBtn, "Copied!", "Copy"))
       .catch(() => {
         const manual = window.prompt("Copy the session ID", sessionId);
         if (manual !== null) {
-          provideCopyFeedback("Copied!");
+          provideCopyFeedback(Reversi.elements.copySessionIdBtn, "Copied!", "Copy");
         }
       });
   }
 
-  function provideCopyFeedback(message) {
-    const { copySessionIdBtn } = Reversi.elements;
-    copySessionIdBtn.textContent = message;
-    copySessionIdBtn.disabled = true;
+  function copySpectatorLink() {
+    if (!Reversi.state.currentSessionSummary || !Reversi.state.currentSessionSummary.sessionId) {
+      return;
+    }
+    const link = window.SpectatorMode.spectatorUrl(
+      window.location.href,
+      Reversi.state.currentSessionSummary.sessionId
+    );
+    const canUseClipboard = navigator.clipboard && navigator.clipboard.writeText;
+    const promise = canUseClipboard ? navigator.clipboard.writeText(link)
+      : Promise.reject(new Error("Clipboard API unavailable"));
+
+    promise
+      .then(() => provideCopyFeedback(Reversi.elements.copyWatchLinkBtn, "Copied!", "Copy watch link"))
+      .catch(() => {
+        const manual = window.prompt("Copy the spectator link", link);
+        if (manual !== null) {
+          provideCopyFeedback(Reversi.elements.copyWatchLinkBtn, "Copied!", "Copy watch link");
+        }
+      });
+  }
+
+  function provideCopyFeedback(button, message, defaultLabel) {
+    button.textContent = message;
+    button.disabled = true;
 
     if (Reversi.state.copyFeedbackTimeout) {
       clearTimeout(Reversi.state.copyFeedbackTimeout);
     }
 
     Reversi.state.copyFeedbackTimeout = setTimeout(() => {
-      copySessionIdBtn.textContent = "Copy";
-      copySessionIdBtn.disabled = false;
+      button.textContent = defaultLabel;
+      button.disabled = false;
       Reversi.state.copyFeedbackTimeout = null;
     }, 2000);
 
@@ -346,6 +491,7 @@
   function quitGame() {
     const { gamePage, menuPage, gameContainer } = Reversi.elements;
     console.log("Quitting game...");
+    disconnectFromSocket();
     gamePage.classList.add("hidden");
     menuPage.classList.remove("hidden");
     gameContainer.classList.add("hidden");
@@ -355,8 +501,18 @@
     Reversi.elements.whiteScoreBox.classList.remove("active");
     Reversi.elements.blackScoreVal.textContent = "0";
     Reversi.elements.whiteScoreVal.textContent = "0";
+    Reversi.elements.gameStatus.textContent = "";
+    const wasSpectating = Reversi.state.isSpectator;
+    Reversi.state.isSpectator = false;
     Reversi.state.clientColor = "WHITE";
+    Reversi.state.currentSessionSummary = null;
+    Reversi.state.lastAnnouncedGameState = null;
     hideSessionInfo();
+    if (wasSpectating) {
+      const menuUrl = new URL(window.location.href);
+      menuUrl.searchParams.delete("spectate");
+      window.history.replaceState(null, "", menuUrl.toString());
+    }
   }
 
   function menuRedirect() {
@@ -366,13 +522,17 @@
   window.Game = {
     startGame,
     joinGame,
+    watchGame,
     enterGame,
     connectToSocket,
-    copySessionId
+    disconnectFromSocket,
+    copySessionId,
+    copySpectatorLink
   };
 
   window.startGame = startGame;
   window.joinGame = joinGame;
+  window.watchGame = watchGame;
   window.quitGame = quitGame;
   window.menuRedirect = menuRedirect;
 })();

--- a/src/main/resources/static/js/menu.js
+++ b/src/main/resources/static/js/menu.js
@@ -32,8 +32,23 @@
     });
   }
 
+  function showWatchGameForm() {
+    const { overlay, overlayTitle, overlayBody } = Reversi.elements;
+    overlay.classList.remove("hidden");
+    overlayTitle.textContent = "Watch a Game";
+    overlayBody.innerHTML = `
+      <input type="text" id="spectatorSessionIdInput" placeholder="Enter Session ID" />
+      <button id="watchBtn">Watch</button>
+      <p id="spectatorError" class="form-error hidden" role="alert"></p>
+    `;
+    document.getElementById("watchBtn").addEventListener("click", function() {
+      window.Game.watchGame();
+    });
+  }
+
   window.Menu = {
     showNewGameOptions,
-    showJoinGameForm
+    showJoinGameForm,
+    showWatchGameForm
   };
 })();

--- a/src/main/resources/static/js/spectator-mode.js
+++ b/src/main/resources/static/js/spectator-mode.js
@@ -1,0 +1,71 @@
+(function(root, factory) {
+  const api = factory();
+  if (typeof module === "object" && module.exports) {
+    module.exports = api;
+  }
+  if (root) {
+    root.SpectatorMode = api;
+  }
+})(typeof window !== "undefined" ? window : null, function() {
+  function spectateSessionIdFromSearch(search) {
+    const params = new URLSearchParams(search || "");
+    const value = params.get("spectate");
+    if (value === null) {
+      return null;
+    }
+    const sessionId = value.trim();
+    return sessionId.length > 0 ? sessionId : null;
+  }
+
+  function isActiveColor(state) {
+    return !!(state.clientColor && state.currentPlayerColor &&
+      state.clientColor.toUpperCase() === state.currentPlayerColor.toUpperCase());
+  }
+
+  function shouldRequestPossibleMoves(state) {
+    return !state.isSpectator && isActiveColor(state);
+  }
+
+  function canInteractWithBoard(state) {
+    return !state.isSpectator && isActiveColor(state);
+  }
+
+  function displayColor(color) {
+    if (!color) {
+      return "Unknown";
+    }
+    const normalized = color.toLowerCase();
+    return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+  }
+
+  function gameStatusText(summary, isSpectator) {
+    if (!summary) {
+      return "";
+    }
+    if (summary.gameState && summary.gameState !== "IN_PROGRESS") {
+      const result = summary.gameState === "TIE"
+        ? "Tie"
+        : displayColor(summary.gameState.replace("_WINS", "")) + " wins";
+      return `Game over: ${result}.`;
+    }
+    const activeTurn = `${displayColor(summary.currentPlayerColor)} to move.`;
+    if (summary.lastPassedPlayerColor) {
+      return `${displayColor(summary.lastPassedPlayerColor)} passed. ${activeTurn}`;
+    }
+    return isSpectator ? `Watching live — ${activeTurn}` : activeTurn;
+  }
+
+  function spectatorUrl(baseUrl, sessionId) {
+    const url = new URL(baseUrl);
+    url.searchParams.set("spectate", sessionId);
+    return url.toString();
+  }
+
+  return {
+    spectateSessionIdFromSearch,
+    shouldRequestPossibleMoves,
+    canInteractWithBoard,
+    gameStatusText,
+    spectatorUrl
+  };
+});

--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -172,10 +172,21 @@ button {
   display: inline-block;
 }
 
+#gameStatus {
+  min-height: 24px;
+  margin: 0 0 12px;
+  font-weight: 600;
+}
+
+.form-error {
+  color: #b00020;
+  margin-bottom: 0;
+}
+
 /* Scoreboard positioned absolutely within gameContainer */
 #scores {
   position: absolute;
-  top: 0;
+  top: 36px;
   left: 0;
   right: 0;
   pointer-events: none;
@@ -242,7 +253,7 @@ button {
 
 /* Board container (CSS grid) */
 #board {
-  margin-top: 60px; /* leave space for scoreboard above */
+  margin-top: 80px; /* leave space for status and scoreboard above */
   display: grid;
   margin-left: auto;
   margin-right: auto;
@@ -258,6 +269,10 @@ button {
   border: 1px solid #006400;
   position: relative;
   box-sizing: border-box;
+}
+
+.cell.interactive {
+  cursor: pointer;
 }
 
 .piece {
@@ -286,4 +301,3 @@ button {
   top: 10%;
   left: 10%;
 }
-

--- a/src/test/java/com/project/reversi/controllers/SessionControllerTest.java
+++ b/src/test/java/com/project/reversi/controllers/SessionControllerTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.reversi.dto.MoveRequestDTO;
 import com.project.reversi.model.Board;
 import com.project.reversi.model.GameSession;
+import com.project.reversi.model.GameState;
 import com.project.reversi.model.GameType;
 import com.project.reversi.model.MoveResult;
 import com.project.reversi.model.Player;
@@ -24,7 +25,9 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -122,6 +125,37 @@ public class SessionControllerTest {
            .andExpect(status().isNotFound());
   }
 
+  @Test
+  @DisplayName("GET /api/v1/sessions/{id} returns a session to an anonymous spectator")
+  void getSessionIsPublicForSpectators() throws Exception {
+    SecurityContextHolder.clearContext();
+    GameSession session = new GameSession(new Board(8, 8), new Player(PlayerColor.WHITE), GameType.PLAYER_VS_PLAYER);
+    Mockito.when(gameSessionService.getSessionById(session.getSessionId())).thenReturn(session);
+
+    mockMvc.perform(get("/api/v1/sessions/" + session.getSessionId()))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.sessionId", is(session.getSessionId())))
+           .andExpect(jsonPath("$.gameState", is("IN_PROGRESS")));
+  }
+
+  @Test
+  @DisplayName("GET /api/v1/sessions/{id} returns the final board and result")
+  void getCompletedSessionForSpectators() throws Exception {
+    SecurityContextHolder.clearContext();
+    GameSession session = new GameSession(new Board(8, 8), new Player(PlayerColor.WHITE), GameType.PLAYER_VS_PLAYER);
+    session.setGameState(GameState.BLACK_WINS);
+    session.setWhiteScore(21);
+    session.setBlackScore(43);
+    Mockito.when(gameSessionService.getSessionById(session.getSessionId())).thenReturn(session);
+
+    mockMvc.perform(get("/api/v1/sessions/" + session.getSessionId()))
+           .andExpect(status().isOk())
+           .andExpect(jsonPath("$.board.boardCells", notNullValue()))
+           .andExpect(jsonPath("$.whiteScore", is(21)))
+           .andExpect(jsonPath("$.blackScore", is(43)))
+           .andExpect(jsonPath("$.gameState", is("BLACK_WINS")));
+  }
+
 
   @Test
   @DisplayName("GET /api/v1/sessions/{id}/board returns board DTO for session")
@@ -162,7 +196,13 @@ public class SessionControllerTest {
   @DisplayName("POST /api/v1/sessions/{id}/moves maps MoveResult to message and returns summary")
   void makeMoveSuccess() throws Exception {
     GameSession session = new GameSession(new Board(8, 8), new Player(PlayerColor.WHITE), GameType.PLAYER_VS_PLAYER);
-    Mockito.when(gameService.makeMove(Mockito.eq(session.getSessionId()), Mockito.anyInt(), Mockito.anyInt(), Mockito.eq(PlayerColor.WHITE)))
+    Mockito.when(gameService.makeMove(
+               Mockito.eq(session.getSessionId()),
+               Mockito.anyInt(),
+               Mockito.anyInt(),
+               Mockito.eq(PlayerColor.WHITE),
+               Mockito.any(User.class)
+           ))
            .thenReturn(MoveResult.SUCCESS);
     Mockito.when(gameService.getSessionById(session.getSessionId())).thenReturn(session);
 
@@ -178,5 +218,54 @@ public class SessionControllerTest {
            .andExpect(jsonPath("$.message", is("Move successful")))
            .andExpect(jsonPath("$.sessionSummary.sessionId", is(session.getSessionId())))
            .andExpect(jsonPath("$.sessionSummary.playerNicknames", notNullValue()));
+  }
+
+  @Test
+  @DisplayName("POST /api/v1/sessions/{id}/moves rejects an anonymous PVP move")
+  void makeMoveRejectsAnonymousPvpCaller() throws Exception {
+    SecurityContextHolder.clearContext();
+    String sessionId = "pvp-session";
+    Mockito.when(gameService.makeMove(
+               Mockito.eq(sessionId),
+               Mockito.anyInt(),
+               Mockito.anyInt(),
+               Mockito.eq(PlayerColor.WHITE),
+               Mockito.isNull()
+           ))
+           .thenThrow(new AuthenticationCredentialsNotFoundException("Authentication required"));
+
+    MoveRequestDTO request = new MoveRequestDTO();
+    request.setRow(2);
+    request.setColumn(3);
+    request.setColor(PlayerColor.WHITE);
+
+    mockMvc.perform(post("/api/v1/sessions/" + sessionId + "/moves")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+           .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @DisplayName("POST /api/v1/sessions/{id}/moves rejects a PVP move from a non-owner")
+  void makeMoveRejectsAuthenticatedNonOwner() throws Exception {
+    String sessionId = "pvp-session";
+    Mockito.when(gameService.makeMove(
+               Mockito.eq(sessionId),
+               Mockito.anyInt(),
+               Mockito.anyInt(),
+               Mockito.eq(PlayerColor.WHITE),
+               Mockito.any(User.class)
+           ))
+           .thenThrow(new AccessDeniedException("Player does not own this color"));
+
+    MoveRequestDTO request = new MoveRequestDTO();
+    request.setRow(2);
+    request.setColumn(3);
+    request.setColor(PlayerColor.WHITE);
+
+    mockMvc.perform(post("/api/v1/sessions/" + sessionId + "/moves")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+           .andExpect(status().isForbidden());
   }
 }

--- a/src/test/java/com/project/reversi/services/GameServiceTest.java
+++ b/src/test/java/com/project/reversi/services/GameServiceTest.java
@@ -8,16 +8,21 @@ import com.project.reversi.model.MoveResult;
 import com.project.reversi.model.Piece;
 import com.project.reversi.model.Player;
 import com.project.reversi.model.PlayerColor;
+import com.project.reversi.model.User;
 import com.project.reversi.repository.JpaGameSessionRepository;
+import com.project.reversi.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 
 import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DataJpaTest
@@ -25,6 +30,9 @@ public class GameServiceTest {
 
   @Autowired
   private JpaGameSessionRepository repository;
+
+  @Autowired
+  private UserRepository userRepository;
 
 
   private GameService gameService;
@@ -35,6 +43,59 @@ public class GameServiceTest {
     ComputerMoveEngine computerMoveEngine = new ComputerMoveEngine(null);
     gameService = new GameService(repository, computerMoveEngine);
     gameSessionService = new GameSessionService(repository);
+  }
+
+  @Test
+  void authenticatedPvpMoveRequiresTheSubmittedColorOwner() {
+    User owner = userRepository.save(new User("white-owner", "password"));
+    User spectator = userRepository.save(new User("spectator", "password"));
+    Player white = new Player(PlayerColor.WHITE);
+    white.setAccount(owner);
+    GameSession session = gameSessionService.createGameSession(GameType.PLAYER_VS_PLAYER, white);
+
+    assertThrows(
+        AccessDeniedException.class,
+        () -> gameService.makeMove(session.getSessionId(), 2, 3, PlayerColor.WHITE, spectator)
+    );
+  }
+
+  @Test
+  void anonymousPvpMoveIsRejected() {
+    User owner = userRepository.save(new User("white-owner", "password"));
+    Player white = new Player(PlayerColor.WHITE);
+    white.setAccount(owner);
+    GameSession session = gameSessionService.createGameSession(GameType.PLAYER_VS_PLAYER, white);
+
+    assertThrows(
+        AuthenticationCredentialsNotFoundException.class,
+        () -> gameService.makeMove(session.getSessionId(), 2, 3, PlayerColor.WHITE, null)
+    );
+  }
+
+  @Test
+  void pvpColorOwnerCanMakeTheActivePlayersMove() {
+    User owner = userRepository.save(new User("white-owner", "password"));
+    Player white = new Player(PlayerColor.WHITE);
+    white.setAccount(owner);
+    GameSession session = gameSessionService.createGameSession(GameType.PLAYER_VS_PLAYER, white);
+
+    MoveResult result = gameService.makeMove(session.getSessionId(), 2, 4, PlayerColor.WHITE, owner);
+
+    assertEquals(MoveResult.SUCCESS, result);
+  }
+
+  @Test
+  void anonymousPlayerVsComputerMoveRemainsAllowed() {
+    GameSession session = gameSessionService.createGameSession(
+        GameType.PLAYER_VS_COMPUTER,
+        new Player(PlayerColor.WHITE)
+    );
+    session.setGameState(GameState.WHITE_WINS);
+    repository.save(session);
+
+    MoveResult result = gameService.makeMove(session.getSessionId(), 2, 4, PlayerColor.WHITE, null);
+
+    assertEquals(MoveResult.GAME_FINISHED, result);
   }
 
   @Test
@@ -101,6 +162,7 @@ public class GameServiceTest {
 
     GameSession saved = repository.findById(session.getSessionId()).orElseThrow();
     assertEquals(0, saved.getCurrentTurnIndex());
+    assertEquals(PlayerColor.BLACK, saved.getLastPassedPlayerColor());
   }
 
   @Test
@@ -214,4 +276,3 @@ public class GameServiceTest {
     public int getPieceCount(PlayerColor color) { return 5; }
   }
 }
-

--- a/src/test/js/spectator-mode.test.js
+++ b/src/test/js/spectator-mode.test.js
@@ -1,0 +1,62 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  spectateSessionIdFromSearch,
+  shouldRequestPossibleMoves,
+  canInteractWithBoard,
+  gameStatusText,
+  spectatorUrl
+} = require("../../main/resources/static/js/spectator-mode.js");
+
+test("direct spectator links return their trimmed session ID", () => {
+  assert.equal(spectateSessionIdFromSearch("?spectate=%20game-123%20"), "game-123");
+});
+
+test("missing or blank spectator parameters do not start spectator mode", () => {
+  assert.equal(spectateSessionIdFromSearch("?other=value"), null);
+  assert.equal(spectateSessionIdFromSearch("?spectate=%20%20"), null);
+});
+
+test("spectators never request legal-move hints", () => {
+  assert.equal(shouldRequestPossibleMoves({
+    isSpectator: true,
+    clientColor: "WHITE",
+    currentPlayerColor: "WHITE"
+  }), false);
+});
+
+test("spectators can never interact with board cells", () => {
+  assert.equal(canInteractWithBoard({
+    isSpectator: true,
+    clientColor: "WHITE",
+    currentPlayerColor: "WHITE"
+  }), false);
+});
+
+test("spectator status identifies the active turn", () => {
+  assert.equal(gameStatusText({
+    gameState: "IN_PROGRESS",
+    currentPlayerColor: "WHITE"
+  }, true), "Watching live — White to move.");
+});
+
+test("spectator status identifies a passed turn", () => {
+  assert.equal(gameStatusText({
+    gameState: "IN_PROGRESS",
+    currentPlayerColor: "WHITE",
+    lastPassedPlayerColor: "BLACK"
+  }, true), "Black passed. White to move.");
+});
+
+test("spectator status renders the completed-game result", () => {
+  assert.equal(gameStatusText({ gameState: "BLACK_WINS" }, true), "Game over: Black wins.");
+  assert.equal(gameStatusText({ gameState: "TIE" }, true), "Game over: Tie.");
+});
+
+test("shareable watch links encode the spectator session ID", () => {
+  assert.equal(
+    spectatorUrl("https://example.test/?other=value#board", "game / 123"),
+    "https://example.test/?other=value&spectate=game+%2F+123#board"
+  );
+});


### PR DESCRIPTION
## Summary

- add a Watch Game flow and direct `?spectate=<sessionId>` links without joining or occupying a player seat
- render live board, scores, player names, active turn, passes, and completed-game results through the existing WebSocket topic
- keep spectator state read-only with no legal-move hints or board interaction
- enforce authenticated PVP color ownership server-side and return 401/403 for unauthorized moves
- add controller/service coverage, dependency-free frontend tests, a feature spec, and focused manual scenarios

## Validation

- `node --test src/test/js/spectator-mode.test.js`
- `mvn test` — 39 tests passed
- `mvn clean install`

Closes #14